### PR TITLE
add temp storage and mock data

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -74,6 +74,10 @@ app.post('/convert', upload.single('file'), (req, res) => {
 
 app.use(express.static('public'));
 
+// Replace with actual product data router
+const mockProductsRouter = require('./routes/mockProducts');
+app.use('/products', mockProductsRouter)
+
 app.use((req, res, next) => {
   next();
 });

--- a/server/mock-data/products.json
+++ b/server/mock-data/products.json
@@ -1,0 +1,8 @@
+[
+    {
+      "name": "Dell UltraSharp 27 Monitor - U2720Q",
+      "sku": 12345678,
+      "price": 699.99,
+      "link": "https://www.bestbuy.ca/en-ca/product/12345678"
+    }
+  ]

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,10 +14,12 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "fs": "^0.0.1-security",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "multer": "^1.4.5-lts.1",
         "mysql2": "^3.10.1",
+        "path": "^0.12.7",
         "uuid": "^10.0.0"
       }
     },
@@ -637,6 +639,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -1416,6 +1423,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1438,6 +1454,14 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
       "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -1827,10 +1851,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -15,10 +15,12 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "fs": "^0.0.1-security",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "multer": "^1.4.5-lts.1",
     "mysql2": "^3.10.1",
+    "path": "^0.12.7",
     "uuid": "^10.0.0"
   }
 }

--- a/server/routes/mockProducts.js
+++ b/server/routes/mockProducts.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const router = express.Router();
+const fs = require('fs');
+const path = require('path')
+
+const jsonProducts = fs.readFileSync(path.resolve(__dirname, '../mock-data/products.json'), 'utf8');
+console.log(jsonProducts)
+const products = JSON.parse(jsonProducts);
+console.log(products)
+
+// Getting all
+router.get('/', (req, res) => {
+    {const productList = products.map((product) => {
+        return (
+            {"name":product.name, "sku":product.sku, "price":product.price, "link":product.link}
+        )
+    })
+    res.json(productList)
+    }
+})
+
+module.exports = router;


### PR DESCRIPTION
- copied and pasted JSON data from csv converter into a JSON mock-data file...products.json in the mock-data folder
- wrote a get request to map over the json file- so far we only have one entry in the json file but the goal is that for now we at least have a get request we can use to model our builds
- i also think once we get our real data we can easily transfer route names and folder locations to replace mock-data
- products is the endpoint for the GET request